### PR TITLE
fix more Mac compilation issues

### DIFF
--- a/ASAP/TileManager.cpp
+++ b/ASAP/TileManager.cpp
@@ -1,4 +1,5 @@
 #include <sstream>
+#include <cmath>
 #include "TileManager.h"
 #include "io/multiresolutionimageinterface/MultiResolutionImage.h"
 #include "RenderThread.h"

--- a/ASAP/annotation/CMakeLists.txt
+++ b/ASAP/annotation/CMakeLists.txt
@@ -1,6 +1,6 @@
 PROJECT(AnnotationPlugin)
 INCLUDE_DIRECTORIES(
-  ${Annotation_SOURCE_DIR}
+  ${ANNOTATION_SOURCE_DIR}
   ${Boost_INCLUDE_DIRS}
   ${PugiXML_INCLUDE_DIR}
   ${DIAGPathology_BINARY_DIR}

--- a/ASAP/annotation/PointSetQtAnnotation.cpp
+++ b/ASAP/annotation/PointSetQtAnnotation.cpp
@@ -5,6 +5,7 @@
 #include <QPainterPathStroker>
 #include <QStyleOptionGraphicsItem>
 #include <iostream>
+#include <cmath>
 
 PointSetQtAnnotation::PointSetQtAnnotation(const std::shared_ptr<Annotation>& annotation, QObject* parent, float scale) : 
   QtAnnotation(annotation, parent, scale),

--- a/ASAP/annotation/PolyQtAnnotation.cpp
+++ b/ASAP/annotation/PolyQtAnnotation.cpp
@@ -5,6 +5,7 @@
 #include <QPainterPathStroker>
 #include <QStyleOptionGraphicsItem>
 #include <iostream>
+#include <cmath>
 
 PolyQtAnnotation::PolyQtAnnotation(const std::shared_ptr<Annotation>& annotation, QObject* parent, float scale) : 
   QtAnnotation(annotation, parent, scale),

--- a/ASAP/pathologyworkstation.cpp
+++ b/ASAP/pathologyworkstation.cpp
@@ -296,6 +296,7 @@ unsigned long long PathologyWorkstation::getCacheSize() const {
   if (view) {
     return view->getCacheSize();
   }
+  return 0; // FIXME: throw error?
 }
 
 void PathologyWorkstation::setupUi()

--- a/annotation/Annotation.cpp
+++ b/annotation/Annotation.cpp
@@ -2,6 +2,7 @@
 #include "AnnotationGroup.h"
 #include "psimpl.h"
 #include <limits>
+#include <cmath>
 
 const char* Annotation::_typeStrings[5] = { "None", "Dot", "Polygon", "Spline", "PointSet"};
 
@@ -32,7 +33,7 @@ float Annotation::getArea() const {
       area += (_coordinates[j].getX() + _coordinates[i].getX())*(_coordinates[j].getY() - _coordinates[i].getY());
       j = i;
     }
-    return abs(area*.5);
+    return std::abs(area*.5);
   }
   else{
     return 0.0;

--- a/annotation/ImageScopeRepository.cpp
+++ b/annotation/ImageScopeRepository.cpp
@@ -159,4 +159,5 @@ bool ImageScopeRepository::loadFromRepo()
     _list->addGroup(grp);
     group_nr += 1;
 	}
+  return true;
 }

--- a/annotation/NDPARepository.cpp
+++ b/annotation/NDPARepository.cpp
@@ -93,4 +93,5 @@ bool NDPARepository::loadFromRepo()
       }
     }
 	}
+  return true;
 }

--- a/core/Box.cpp
+++ b/core/Box.cpp
@@ -77,8 +77,11 @@ Box Box::intersection(const Box& b) const {
   std::vector<unsigned long long> start(_start.size(),0), size(_start.size(),0);
   for (int i = 0; i < _start.size(); ++i) {
     start[i] = std::max(_start[i], b.getStart()[i]);
-    size[i] = std::min(_start[i] + _size[i], b.getStart()[i] + b.getSize()[i]) - start[i];
-    if (size[i] < 0) size[i] = 0;
+    unsigned long long end = std::min(_start[i] + _size[i], b.getStart()[i] + b.getSize()[i]);
+    if(end > start[i])
+      size[i] = end - start[i];
+    else
+      size[i] = 0;
   }
 
   return Box(start, size);

--- a/core/Patch.h
+++ b/core/Patch.h
@@ -23,7 +23,8 @@ public :
   Patch();
   ~Patch();
   Patch(const Patch& rhs);
-  Patch& operator=(const Patch rhs);
+  Patch& operator=(const Patch &rhs);
+  Patch& operator=(Patch &&rhs);
   Patch(const std::vector<unsigned long long>& dimensions, const pathology::ColorType& ctype = pathology::Monochrome, T* data = NULL, bool ownData = true);
 
   // Arithmetic operators

--- a/core/Patch.hpp
+++ b/core/Patch.hpp
@@ -125,7 +125,7 @@ Patch<T>::Patch(const std::vector<unsigned long long>& dimensions, const patholo
   }
   if (!dimensions.empty()) {
     if ((_colorType == pathology::ARGB && dimensions.back() != 4) || (_colorType == pathology::RGB && dimensions.back() != 3) || (_colorType == pathology::Monochrome && dimensions.back() != 1)) {
-      _colorType == pathology::Indexed;
+      _colorType = pathology::Indexed;
     }
   }
   calculateStrides();

--- a/core/Patch.hpp
+++ b/core/Patch.hpp
@@ -157,7 +157,18 @@ void Patch<T>::swap(Patch<T>& first, Patch<T>& second) {
 }
 
 template<typename T>
-Patch<T>& Patch<T>::operator=(Patch<T> rhs) {
+Patch<T>& Patch<T>::operator=(const Patch<T> &rhs) {
+  ImageSource::operator=(rhs);
+  _dimensions = rhs._dimensions;
+  _buffer = rhs._buffer;
+  _bufferSize = rhs._bufferSize;
+  _ownData = rhs._ownData;
+  _strides = rhs._strides;
+  return *this;
+}
+
+template<typename T>
+Patch<T>& Patch<T>::operator=(Patch<T> &&rhs) {
   this->swap(*this, rhs);
   return *this;
 }

--- a/core/filetools.cpp
+++ b/core/filetools.cpp
@@ -436,7 +436,7 @@ namespace core
     string fixedPath = _fixedPath;
 
 //if a relative path cannot be written
-    if (! (rootName(pathToAlter)).compare(rootName(fixedPath)) == 0 )
+    if ( (rootName(pathToAlter)).compare(rootName(fixedPath)) != 0 )
       return pathToAlter;
 //if the two paths are the same
     if ( pathToAlter.compare(fixedPath) == 0)

--- a/imgproc/basicfilters/ColorDeconvolutionFilter.h
+++ b/imgproc/basicfilters/ColorDeconvolutionFilter.h
@@ -1,6 +1,7 @@
 #ifndef _ColorDeconvolutionFilter
 #define _ColorDeconvolutionFilter
 
+#include <cmath>
 #include <map>
 #include <string>
 #include <vector>
@@ -40,9 +41,9 @@ class ColorDeconvolutionFilter :  public ImageFilter<inType, double> {
           }
         }
         if (rgb[0] != 0 && rgb[1] != 0 && rgb[2] != 0) {
-          double Rlog = -log(rgb[0] / 255.0);
-          double Glog = -log(rgb[1] / 255.0);
-          double Blog = -log(rgb[2] / 255.0);
+          double Rlog = -std::log(rgb[0] / 255.0);
+          double Glog = -std::log(rgb[1] / 255.0);
+          double Blog = -std::log(rgb[2] / 255.0);
           double val = 0.0;
           if ((Rlog + Glog + Blog) / 3. > _globalThreshold && Rlog > _rgbThresholds[0] && Glog > _rgbThresholds[1] && Blog > _rgbThresholds[2]) {
             double Rscaled = Rlog * _q[_outputStain * 3];
@@ -84,7 +85,7 @@ class ColorDeconvolutionFilter :  public ImageFilter<inType, double> {
     for (unsigned int i = 0; i<3; ++i){
       /* normalise vector length */
       cosx[i] = cosy[i] = cosz[i] = 0.0;
-      len[i] = sqrt(_modX[i] * _modX[i] + _modY[i] * _modY[i] + _modZ[i] * _modZ[i]);
+      len[i] = std::sqrt(_modX[i] * _modX[i] + _modY[i] * _modY[i] + _modZ[i] * _modZ[i]);
       if (len[i] != 0.0){
         cosx[i] = _modX[i] / len[i];
         cosy[i] = _modY[i] / len[i];
@@ -109,22 +110,22 @@ class ColorDeconvolutionFilter :  public ImageFilter<inType, double> {
           if ((cosx[0] * cosx[0] + cosx[1] * cosx[1])> 1)
             cosx[2] = 0.0;
           else
-            cosx[2] = sqrt(1.0 - (cosx[0] * cosx[0]) - (cosx[1] * cosx[1]));
+            cosx[2] = std::sqrt(1.0 - (cosx[0] * cosx[0]) - (cosx[1] * cosx[1]));
 
           if ((cosy[0] * cosy[0] + cosy[1] * cosy[1])> 1)
             cosy[2] = 0.0;
           else
-            cosy[2] = sqrt(1.0 - (cosy[0] * cosy[0]) - (cosy[1] * cosy[1]));
+            cosy[2] = std::sqrt(1.0 - (cosy[0] * cosy[0]) - (cosy[1] * cosy[1]));
 
           if ((cosz[0] * cosz[0] + cosz[1] * cosz[1])> 1)
             cosz[2] = 0.0;
           else
-            cosz[2] = sqrt(1.0 - (cosz[0] * cosz[0]) - (cosz[1] * cosz[1]));
+            cosz[2] = std::sqrt(1.0 - (cosz[0] * cosz[0]) - (cosz[1] * cosz[1]));
         }
       }
     }
 
-    double leng = sqrt(cosx[2] * cosx[2] + cosy[2] * cosy[2] + cosz[2] * cosz[2]);
+    double leng = std::sqrt(cosx[2] * cosx[2] + cosy[2] * cosy[2] + cosz[2] * cosz[2]);
 
     cosx[2] = cosx[2] / leng;
     cosy[2] = cosy[2] / leng;

--- a/imgproc/wholeslide/DistanceTransformWholeSlideFilter.cpp
+++ b/imgproc/wholeslide/DistanceTransformWholeSlideFilter.cpp
@@ -6,6 +6,7 @@
 #include "core/filetools.h"
 #include <set>
 #include <iostream>
+#include <cmath>
 
 DistanceTransformWholeSlideFilter::DistanceTransformWholeSlideFilter() :
 _monitor(NULL),

--- a/io/multiresolutionimageinterface/LIFImage.cpp
+++ b/io/multiresolutionimageinterface/LIFImage.cpp
@@ -1,6 +1,7 @@
 #include "LIFImage.h"
 #include <fstream>
 #include <iostream>
+#include <cmath>
 #include "core/filetools.h"
 #include "core/stringconversion.h"
 #include "core/PathologyEnums.h"
@@ -553,7 +554,7 @@ void LIFImage::translateImageNodes(pugi::xpath_node&  imageNode, int imageNr)
   _physicalSizeYs.push_back(physicalSizeY);
 
   if (_zSteps[imageNr] == 0.0 && physicalSizeZ != 0.0) {
-    _zSteps[imageNr] = abs(physicalSizeZ);
+    _zSteps[imageNr] = std::abs(physicalSizeZ);
   }
 
   if (extras > 1) {

--- a/io/multiresolutionimageinterface/LIFImage.cpp
+++ b/io/multiresolutionimageinterface/LIFImage.cpp
@@ -122,7 +122,7 @@ bool LIFImage::initialize(const std::string& imagePath) {
       }
     }
     if (index < nc*2) {
-      editedXml[index] = NULL;
+      editedXml[index] = '\0';
     }
     std::string xml(editedXml);
 

--- a/io/multiresolutionimageinterface/MultiResolutionImage.cpp
+++ b/io/multiresolutionimageinterface/MultiResolutionImage.cpp
@@ -1,5 +1,6 @@
 #include "MultiResolutionImage.h"
 #include "boost/thread.hpp"
+#include <cmath>
 
 using namespace pathology;
 
@@ -168,7 +169,7 @@ const int MultiResolutionImage::getBestLevelForDownSample(const double& downsamp
       double previousDownSample = (double)_levelDimensions[0][0] / (double)_levelDimensions[i-1][0];
       if (downsample<currentDownSample) {
         
-        if (abs(currentDownSample - downsample) > abs(previousDownSample - downsample)) {
+        if (std::abs(currentDownSample - downsample) > std::abs(previousDownSample - downsample)) {
           return i - 1;
         }
         else {


### PR DESCRIPTION
This mostly lets the workstation compile with MacPorts.  Remaining
issues:
1. The code assumes that opencv 3.1.0 is build with the "world" DLL;
   using the other CMake code path still works.
2. There are linker issues, that could be fixed by turning ASAP into a
   DLL (ASAP_main, for instance) that can be properly linked
   against. (Disclaimer: I don't know if this is the only possible fix,
   but right now, exporting symbols from the main executable does
   not work with CLang.)
