### PR TITLE
Convert cv:Mat.data to (T*) (otherwise is always uchar*)

### DIFF
--- a/imgproc/opencv/DIAGPathologyOpenCVBridge.h
+++ b/imgproc/opencv/DIAGPathologyOpenCVBridge.h
@@ -25,7 +25,7 @@ Patch<T> matToPatch(const cv::Mat& mat, bool copyData = false) {
   Patch<T> output;
   if (copyData) {
     output = Patch<T>(dims, ctype);
-    std::copy(mat.data, mat.data + mat.cols*mat.rows*mat.channels(), output.getPointer());
+    std::copy((T*) mat.data, ((T*) mat.data) + mat.cols*mat.rows*mat.channels(), output.getPointer());
   }
   else {
     output = Patch<T>(dims, ctype, (T*)mat.data, copyData);


### PR DESCRIPTION
cv::Mat.data is a pointer to uchar, so it should be converted to T* in order for std::copy to always work correctly. E.g., converting a cv::Mat of doubles (with copy enabled) does not work properly.