### PR TITLE
Replaced 'ARGB' with 'RGBA'

### DIFF
--- a/imgproc/opencv/DIAGPathologyOpenCVBridge.h
+++ b/imgproc/opencv/DIAGPathologyOpenCVBridge.h
@@ -13,7 +13,7 @@ Patch<T> matToPatch(const cv::Mat& mat, bool copyData = false) {
   dims.push_back(mat.channels());  
   pathology::ColorType ctype = pathology::ColorType::RGB;
   if (mat.channels() == 4) {
-    ctype = pathology::ColorType::ARGB;
+    ctype = pathology::ColorType::RGBA;
   }
   else if (mat.channels() == 1) {
     ctype = pathology::ColorType::Monochrome;


### PR DESCRIPTION
This PR replaces an undefined constant `pathology::ColorType::ARGB` with `pathology::ColorType::RGBA`.

Probably commit 8c462a26 missed replacing this line.