### PR TITLE
Add support for python 3.9 and 3.10.

### DIFF
--- a/buildtools/Dockerfile
+++ b/buildtools/Dockerfile
@@ -49,12 +49,11 @@ RUN wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.s
     rm -f Miniconda3-latest-Linux-x86_64.sh
 
 RUN /root/miniconda3/bin/conda update --quiet -n base -c defaults conda && \
-    /root/miniconda3/bin/conda create --quiet --name build_python3.6m python=3.6 && \
-    /root/miniconda3/bin/conda install --quiet -n build_python3.6m numpy nomkl &&\
-    /root/miniconda3/bin/conda create --quiet --name build_python3.7m python=3.7 && \
-    /root/miniconda3/bin/conda install --quiet -n build_python3.7m numpy nomkl && \
-    /root/miniconda3/bin/conda create --quiet --name build_python3.8 python=3.8 && \
-    /root/miniconda3/bin/conda install --quiet -n build_python3.8 numpy nomkl
+    /root/miniconda3/bin/conda create --quiet --name build_python3.6m python=3.6 numpy nomkl && \
+    /root/miniconda3/bin/conda create --quiet --name build_python3.7m python=3.7 numpy nomkl && \
+    /root/miniconda3/bin/conda create --quiet --name build_python3.8 python=3.8 numpy nomkl && \
+    /root/miniconda3/bin/conda create --quiet --name build_python3.9 python=3.9 numpy nomkl && \
+    /root/miniconda3/bin/conda create --quiet --name build_python3.10 python=3.10 numpy nomkl
 
 RUN ln -sd /root/miniconda3/envs/build_python3.7m/lib/python3.7 /root/miniconda3/envs/build_python3.7m/lib/python3.7m && \
     ln -sd /root/miniconda3/envs/build_python3.6m/lib/python3.6 /root/miniconda3/envs/build_python3.6m/lib/python3.6m


### PR DESCRIPTION
Extended the list of created python environments by adding python 3.9 and 3.10 so the `multiresolutionimageinterface` could be built against those versions too.